### PR TITLE
Implemented the quick-add polish end to end

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -7,20 +7,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusBar: StatusBarController!
     private var hotKeyService: HotKeyService!
     let settings = SettingsStore()
+    let remindersService = EventKitRemindersService()
     private let scheduler = NotificationScheduler()
-    private let api: RemindersAPI = EventKitRemindersService()
-    private let dateParser: DateParsing = SoulverDateParser()
+    private let inputParser: ReminderInputParsing = QuickAddInputParser()
     private var paletteController: CommandPaletteWindowController!
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         requestNotificationPermissionsIfNeeded()
-        let vm = PaletteViewModel(api: api, settings: settings, scheduler: scheduler, dateParser: dateParser)
+        let vm = PaletteViewModel(api: remindersService, settings: settings, scheduler: scheduler, inputParser: inputParser)
         paletteController = CommandPaletteWindowController(viewModel: vm)
         statusBar = StatusBarController(paletteController: paletteController, settings: settings)
         let controller = paletteController
         hotKeyService = HotKeyService { @Sendable [weak controller] in
             Task { @MainActor in
                 controller?.toggle()
+            }
+        }
+
+        if ProcessInfo.processInfo.environment["SLASH_REMIND_SHOW_PALETTE_ON_LAUNCH"] == "1" {
+            DispatchQueue.main.async { [weak self] in
+                self?.paletteController.show()
             }
         }
     }
@@ -30,7 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func requestNotificationPermissionsIfNeeded() {
-        guard settings.syncEnabled else { return }
+        guard settings.notificationsEnabled else { return }
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, _ in
             os_log("notification permission %{public}@", log: .notifications, type: .info, granted ? "granted" : "denied")
         }

--- a/Palette/CommandPaletteView.swift
+++ b/Palette/CommandPaletteView.swift
@@ -8,9 +8,23 @@ struct CommandPaletteView: View {
 
     @FocusState private var isTextFieldFocused: Bool
     @State private var dismissWorkItem: DispatchWorkItem?
+    @State private var exampleIndex = 0
+
+    private let exampleTimer = Timer.publish(every: 4.0, on: .main, in: .common).autoconnect()
+    private let examples = [
+        "buy milk tomorrow at 9am",
+        "call Sam this afternoon",
+        "submit expenses next Friday",
+        "take out the bins tonight",
+        "book dentist appointment Monday at 10am"
+    ]
 
     private var canSubmit: Bool {
         !viewModel.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isSubmitting && !viewModel.didCreateReminder
+    }
+
+    private var currentExample: String {
+        examples[exampleIndex % examples.count]
     }
 
     var body: some View {
@@ -40,6 +54,12 @@ struct CommandPaletteView: View {
         .onChange(of: viewModel.focusRequestID) { _ in
             focusTextField()
         }
+        .onReceive(exampleTimer) { _ in
+            guard viewModel.text.isEmpty else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                exampleIndex = (exampleIndex + 1) % examples.count
+            }
+        }
         .onChange(of: viewModel.didCreateReminder) { didCreateReminder in
             guard didCreateReminder else { return }
             NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
@@ -59,7 +79,7 @@ struct CommandPaletteView: View {
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(viewModel.didCreateReminder ? Color.green : Color.secondary)
 
-            TextField("Remind me to follow up tomorrow at 9am", text: $viewModel.text)
+            TextField(currentExample, text: $viewModel.text)
                 .focused($isTextFieldFocused)
                 .onSubmit {
                     guard canSubmit else { return }

--- a/Palette/CommandPaletteView.swift
+++ b/Palette/CommandPaletteView.swift
@@ -7,21 +7,10 @@ struct CommandPaletteView: View {
     var onDismiss: () -> Void = {}
 
     @FocusState private var isTextFieldFocused: Bool
-    @StateObject private var focusCoordinator = FocusCoordinator()
     @State private var dismissWorkItem: DispatchWorkItem?
 
     private var canSubmit: Bool {
         !viewModel.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !viewModel.isSubmitting && !viewModel.didCreateReminder
-    }
-
-    private class FocusCoordinator: ObservableObject {
-        @Published var shouldFocus: Bool = false
-
-        func triggerFocus() {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                self.shouldFocus = true
-            }
-        }
     }
 
     var body: some View {
@@ -43,19 +32,13 @@ struct CommandPaletteView: View {
         )
         .background(KeyEventHandling(onEscape: onDismiss))
         .onAppear {
-            focusCoordinator.triggerFocus()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                isTextFieldFocused = true
-            }
+            focusTextField()
         }
         .onDisappear {
             dismissWorkItem?.cancel()
         }
-        .onReceive(focusCoordinator.$shouldFocus) { shouldFocus in
-            if shouldFocus {
-                isTextFieldFocused = true
-                focusCoordinator.shouldFocus = false
-            }
+        .onChange(of: viewModel.focusRequestID) { _ in
+            focusTextField()
         }
         .onChange(of: viewModel.didCreateReminder) { didCreateReminder in
             guard didCreateReminder else { return }
@@ -80,11 +63,14 @@ struct CommandPaletteView: View {
                 .focused($isTextFieldFocused)
                 .onSubmit {
                     guard canSubmit else { return }
-                    viewModel.submit()
+                    Task {
+                        await viewModel.submit()
+                    }
                 }
                 .textFieldStyle(.plain)
                 .font(.system(size: 18, weight: .regular))
                 .disabled(viewModel.isSubmitting || viewModel.didCreateReminder)
+                .accessibilityIdentifier("quickAddTextField")
 
             if viewModel.isSubmitting {
                 ProgressView()
@@ -150,6 +136,16 @@ struct CommandPaletteView: View {
             KeyBadge(text: "/")
         }
         .font(.system(size: 11, weight: .medium))
+    }
+
+    private func focusTextField() {
+        isTextFieldFocused = false
+        DispatchQueue.main.async {
+            isTextFieldFocused = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            isTextFieldFocused = true
+        }
     }
 }
 

--- a/Palette/CommandPaletteWindowController.swift
+++ b/Palette/CommandPaletteWindowController.swift
@@ -4,8 +4,22 @@ import SwiftUI
 import QuartzCore
 
 final class KeyablePanel: NSPanel {
+    var onCancel: (() -> Void)?
+
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {
+            onCancel?()
+            return
+        }
+        super.keyDown(with: event)
+    }
 }
 
 @MainActor
@@ -13,6 +27,7 @@ final class CommandPaletteWindowController: NSWindowController {
     private let viewModel: PaletteViewModel
     private var hostingView: NSHostingView<CommandPaletteView>!
     private var isAnimatingHide = false
+    private var observers: [NSObjectProtocol] = []
 
     private let paletteSize = NSSize(width: 520, height: 168)
 
@@ -28,7 +43,7 @@ final class CommandPaletteWindowController: NSWindowController {
 
         panel.level = .floating
         panel.isFloatingPanel = true
-        panel.hidesOnDeactivate = false
+        panel.hidesOnDeactivate = true
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.titleVisibility = .hidden
@@ -37,6 +52,10 @@ final class CommandPaletteWindowController: NSWindowController {
 
         super.init(window: panel)
 
+        panel.onCancel = { [weak self] in
+            self?.hide()
+        }
+
         let content = CommandPaletteView(viewModel: viewModel, onDismiss: { [weak self] in
             self?.hide()
         })
@@ -44,10 +63,37 @@ final class CommandPaletteWindowController: NSWindowController {
         self.hostingView.canDrawConcurrently = false
         panel.contentView = self.hostingView
         panel.initialFirstResponder = self.hostingView
+
+        observers = [
+            NotificationCenter.default.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: panel,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.hide(animated: false)
+                }
+            },
+            NotificationCenter.default.addObserver(
+                forName: NSApplication.didResignActiveNotification,
+                object: NSApp,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.hide(animated: false)
+                }
+            }
+        ]
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    deinit {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
 
     func toggle() {
         if window?.isVisible == true {
@@ -61,6 +107,7 @@ final class CommandPaletteWindowController: NSWindowController {
         guard let window = window, !window.isVisible else { return }
 
         viewModel.reset()
+        viewModel.requestFocus()
         window.setFrame(centeredFrame(for: paletteSize), display: false)
 
         let finalFrame = window.frame
@@ -72,15 +119,21 @@ final class CommandPaletteWindowController: NSWindowController {
 
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(hostingView)
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.16
             context.timingFunction = CAMediaTimingFunction(name: .easeOut)
             window.animator().alphaValue = 1
             window.animator().setFrame(finalFrame, display: true)
-        } completionHandler: {
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+        } completionHandler: { [weak self] in
+            Task { @MainActor in
+                guard let self, let window = self.window else { return }
+                window.makeKeyAndOrderFront(nil)
+                window.makeFirstResponder(self.hostingView)
+                self.viewModel.requestFocus()
+                NSApp.activate(ignoringOtherApps: true)
+            }
         }
     }
 
@@ -116,13 +169,24 @@ final class CommandPaletteWindowController: NSWindowController {
     }
 
     private func centeredFrame(for size: NSSize) -> NSRect {
-        guard let screenFrame = NSScreen.main?.visibleFrame else {
+        guard let screenFrame = targetScreen()?.visibleFrame else {
             return NSRect(origin: .zero, size: size)
         }
 
         let x = screenFrame.midX - (size.width / 2)
         let y = screenFrame.midY - (size.height / 2)
         return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private func targetScreen() -> NSScreen? {
+        if let keyWindowScreen = NSApp.keyWindow?.screen {
+            return keyWindowScreen
+        }
+
+        let mouseLocation = NSEvent.mouseLocation
+        return NSScreen.screens.first { screen in
+            NSMouseInRect(mouseLocation, screen.frame, false)
+        } ?? NSScreen.main
     }
 }
 #endif

--- a/Preferences/PreferencesWindow.swift
+++ b/Preferences/PreferencesWindow.swift
@@ -3,6 +3,12 @@ import SwiftUI
 
 struct PreferencesWindow: View {
     @ObservedObject var settings: SettingsStore
+    let listProvider: any ReminderListProviding
+
+    @State private var reminderLists: [ReminderList] = []
+    @State private var isLoadingLists = false
+    @State private var listError: String?
+
     var body: some View {
         Form {
             Section(header: Text("Hotkey")) {
@@ -14,12 +20,54 @@ struct PreferencesWindow: View {
                         .disabled(true)
                 }
             }
+            Section(header: Text("Reminders")) {
+                Picker("Default List", selection: $settings.defaultReminderListIdentifier) {
+                    Text("Reminders Default").tag(Optional<String>.none)
+                    ForEach(reminderLists) { list in
+                        Text(list.title).tag(Optional(list.id))
+                    }
+                }
+                .disabled(isLoadingLists)
+
+                DatePicker("Default Time", selection: $settings.defaultTime, displayedComponents: .hourAndMinute)
+
+                if let listError {
+                    Text(listError)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if selectedListIsMissing {
+                    Text("The selected list is unavailable. New reminders will use the Reminders default list.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
             Section(header: Text("Notifications")) {
-                Toggle("Enable local notifications", isOn: $settings.syncEnabled)
+                Toggle("Enable local notifications", isOn: $settings.notificationsEnabled)
             }
         }
         .padding(20)
-        .frame(width: 400)
+        .frame(width: 440)
+        .task {
+            await loadReminderLists()
+        }
+    }
+
+    private var selectedListIsMissing: Bool {
+        guard let selectedID = settings.defaultReminderListIdentifier, !reminderLists.isEmpty else {
+            return false
+        }
+        return !reminderLists.contains { $0.id == selectedID }
+    }
+
+    private func loadReminderLists() async {
+        isLoadingLists = true
+        listError = nil
+        do {
+            reminderLists = try await listProvider.reminderLists()
+        } catch {
+            listError = "Reminder lists could not be loaded. The default Reminders list will be used."
+        }
+        isLoadingLists = false
     }
 }
 #endif

--- a/Services/DateParsingService.swift
+++ b/Services/DateParsingService.swift
@@ -5,15 +5,24 @@ import os.log
 #endif
 
 protocol DateParsing: Sendable {
-    func parseDate(from text: String) -> Date?
+    func parseDate(from text: String, defaultTime: DateComponents) -> Date?
+}
+
+struct ParsedReminderInput: Equatable {
+    let title: String
+    let dueDate: Date
+}
+
+protocol ReminderInputParsing: Sendable {
+    func parse(_ text: String, defaultTime: DateComponents) -> ParsedReminderInput?
 }
 
 // @unchecked Sendable: SoulverCore String.dateValue is stateless pure function with no mutable state
 final class SoulverDateParser: DateParsing, @unchecked Sendable {
-    func parseDate(from text: String) -> Date? {
+    func parseDate(from text: String, defaultTime: DateComponents) -> Date? {
         guard let parsedDate = text.dateValue else {
 #if canImport(os)
-            os_log("Date parsing failed for text: %{public}@", log: .services, type: .debug, text)
+            os_log("Date parsing failed", log: .services, type: .debug)
 #endif
             return nil
         }
@@ -27,8 +36,10 @@ final class SoulverDateParser: DateParsing, @unchecked Sendable {
             return parsedDate
         }
 
-        if hour == 12 && minute == 0 && second == 0 {
-            if let adjustedDate = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: parsedDate) {
+        if hour == 12 && minute == 0 && second == 0 && !text.localizedCaseInsensitiveContains("noon") {
+            let defaultHour = defaultTime.hour ?? 9
+            let defaultMinute = defaultTime.minute ?? 0
+            if let adjustedDate = calendar.date(bySettingHour: defaultHour, minute: defaultMinute, second: 0, of: parsedDate) {
                 return adjustedDate
             } else {
 #if canImport(os)
@@ -39,5 +50,167 @@ final class SoulverDateParser: DateParsing, @unchecked Sendable {
         }
 
         return parsedDate
+    }
+}
+
+final class QuickAddInputParser: ReminderInputParsing, @unchecked Sendable {
+    private let dateParser: DateParsing
+
+    init(dateParser: DateParsing = SoulverDateParser()) {
+        self.dateParser = dateParser
+    }
+
+    func parse(_ text: String, defaultTime: DateComponents) -> ParsedReminderInput? {
+        let message = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty,
+              let dueDate = dateParser.parseDate(from: message, defaultTime: defaultTime) else {
+            return nil
+        }
+
+        let title = cleanedTitle(from: message, dueDate: dueDate, defaultTime: defaultTime)
+        return ParsedReminderInput(title: title, dueDate: dueDate)
+    }
+
+    private func cleanedTitle(from message: String, dueDate: Date, defaultTime: DateComponents) -> String {
+        guard let range = dateSuffixRange(in: message, dueDate: dueDate, defaultTime: defaultTime) else {
+            return message
+        }
+
+        var title = message
+        title.removeSubrange(range)
+        title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        title = title.trimmingCharacters(in: CharacterSet(charactersIn: ",.;:-"))
+        title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return title.isEmpty ? "Reminder" : title
+    }
+
+    private func dateSuffixRange(in message: String, dueDate: Date, defaultTime: DateComponents) -> Range<String.Index>? {
+        let tokens = tokens(in: message)
+        let candidates = candidateSuffixRanges(from: tokens, in: message)
+
+        for range in candidates {
+            let candidate = String(message[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !candidate.isEmpty,
+                  let candidateDate = dateParser.parseDate(from: candidate, defaultTime: defaultTime),
+                  datesMatch(candidateDate, dueDate) else {
+                continue
+            }
+            return range
+        }
+
+        return nil
+    }
+
+    private struct Token {
+        let text: String
+        let range: Range<String.Index>
+    }
+
+    private func tokens(in text: String) -> [Token] {
+        let pattern = #"\b[\p{L}\p{N}:/.]+\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: nsRange).compactMap { match in
+            guard let range = Range(match.range, in: text) else { return nil }
+            return Token(text: String(text[range]), range: range)
+        }
+    }
+
+    private func candidateSuffixRanges(from tokens: [Token], in text: String) -> [Range<String.Index>] {
+        guard !tokens.isEmpty else { return [] }
+
+        var ranges: [Range<String.Index>] = []
+        for index in tokens.indices where isDateCore(tokens[index].text, next: tokens[safe: index + 1]?.text) {
+            let startIndex = candidateStartIndex(forCoreAt: index, tokens: tokens)
+            let range = tokens[startIndex].range.lowerBound..<text.endIndex
+            if !ranges.contains(where: { $0 == range }) {
+                ranges.append(range)
+            }
+        }
+
+        ranges.sort { lhs, rhs in
+            lhs.lowerBound < rhs.lowerBound
+        }
+        return ranges
+    }
+
+    private func candidateStartIndex(forCoreAt index: Int, tokens: [Token]) -> Int {
+        guard index > tokens.startIndex else { return index }
+
+        let previous = tokens[index - 1].text.lowercased()
+        let current = tokens[index].text.lowercased()
+
+        if ["next", "this", "last"].contains(previous) {
+            return index - 1
+        }
+
+        if ["at", "on", "by", "before", "after", "due"].contains(previous) {
+            return index - 1
+        }
+
+        if previous == "in", isDurationQuantity(current, next: tokens[safe: index + 1]?.text) {
+            return index - 1
+        }
+
+        return index
+    }
+
+    private func isDateCore(_ token: String, next: String?) -> Bool {
+        let lowercased = token.lowercased()
+        if relativeDateWords.contains(lowercased) || weekdays.contains(lowercased) || months.contains(lowercased) {
+            return true
+        }
+
+        if isTime(lowercased) || isNumericDate(lowercased) || isDurationQuantity(lowercased, next: next) {
+            return true
+        }
+
+        return false
+    }
+
+    private func isTime(_ token: String) -> Bool {
+        token.range(of: #"^\d{1,2}(:\d{2})?\s?(am|pm)$"#, options: .regularExpression) != nil ||
+            token == "noon" ||
+            token == "midnight"
+    }
+
+    private func isNumericDate(_ token: String) -> Bool {
+        token.range(of: #"^\d{1,2}[/.-]\d{1,2}([/.-]\d{2,4})?$"#, options: .regularExpression) != nil
+    }
+
+    private func isDurationQuantity(_ token: String, next: String?) -> Bool {
+        guard Int(token) != nil, let next else { return false }
+        return durationUnits.contains(next.lowercased())
+    }
+
+    private func datesMatch(_ lhs: Date, _ rhs: Date) -> Bool {
+        abs(lhs.timeIntervalSince(rhs)) < 2
+    }
+
+    private let relativeDateWords: Set<String> = [
+        "today", "tomorrow", "tonight", "yesterday", "morning", "afternoon", "evening", "weekend"
+    ]
+
+    private let weekdays: Set<String> = [
+        "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+        "mon", "tue", "tues", "wed", "thu", "thur", "thurs", "fri", "sat", "sun"
+    ]
+
+    private let months: Set<String> = [
+        "january", "february", "march", "april", "may", "june",
+        "july", "august", "september", "october", "november", "december",
+        "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept", "oct", "nov", "dec"
+    ]
+
+    private let durationUnits: Set<String> = [
+        "minute", "minutes", "min", "mins", "hour", "hours", "hr", "hrs", "day", "days", "week", "weeks"
+    ]
+}
+
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Services/EventKitRemindersService.swift
+++ b/Services/EventKitRemindersService.swift
@@ -4,47 +4,49 @@ import EventKit
 import os.log
 #endif
 
-final class EventKitRemindersService: RemindersAPI, @unchecked Sendable {
-    private let store = EKEventStore()
+final class EventKitRemindersService: RemindersAPI, ReminderListProviding, @unchecked Sendable {
+    private let store: EKEventStore
 
-    func createReminder(text: String, dueDate: Date?) async throws {
-        let granted: Bool
-        if #available(macOS 14.0, *) {
-            granted = try await store.requestFullAccessToReminders()
-        } else {
-            granted = try await withCheckedThrowingContinuation { continuation in
-                store.requestAccess(to: .reminder) { granted, error in
-                    if let error = error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume(returning: granted)
-                    }
-                }
-            }
+    init(store: EKEventStore = EKEventStore()) {
+        self.store = store
+    }
+
+    func reminderLists() async throws -> [ReminderList] {
+        guard try await requestRemindersAccess() else {
+#if canImport(os)
+            os_log("EventKit access denied while loading reminder lists", log: .services, type: .error)
+#endif
+            throw EventKitError.accessDenied
         }
 
-        guard granted else {
+        return store.calendars(for: .reminder)
+            .map { ReminderList(id: $0.calendarIdentifier, title: $0.title) }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
+    func createReminder(title: String, dueDate: Date?, calendarIdentifier: String?) async throws {
+        guard try await requestRemindersAccess() else {
 #if canImport(os)
             os_log("EventKit access denied", log: .services, type: .error)
 #endif
-            throw NSError(domain: "EventKitRemindersService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Calendar access denied"])
+            throw EventKitError.accessDenied
         }
 
         let reminder = EKReminder(eventStore: store)
-        reminder.title = text
+        reminder.title = title
 
-        guard let calendar = store.defaultCalendarForNewReminders() else {
+        guard let calendar = reminderCalendar(matching: calendarIdentifier) else {
 #if canImport(os)
             os_log("No default calendar available", log: .services, type: .error)
 #endif
-            throw NSError(domain: "EventKitRemindersService", code: 2, userInfo: [NSLocalizedDescriptionKey: "No default calendar"])
+            throw EventKitError.noDefaultCalendar
         }
 
         if let dueDate = dueDate {
             let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: dueDate)
             guard components.year != nil, components.month != nil, components.day != nil else {
 #if canImport(os)
-                os_log("Failed to extract date components from dueDate", log: .services, type: .error)
+                os_log("Failed to extract date components from due date", log: .services, type: .error)
 #endif
                 throw NSError(domain: "EventKitRemindersService", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid date format"])
             }
@@ -57,8 +59,33 @@ final class EventKitRemindersService: RemindersAPI, @unchecked Sendable {
 
         try store.save(reminder, commit: true)
 #if canImport(os)
-        os_log("Created reminder: %{public}@", log: .services, type: .info, text)
+        os_log("Created reminder due_date_present=%{public}@", log: .services, type: .info, dueDate == nil ? "false" : "true")
 #endif
+    }
+
+    private func requestRemindersAccess() async throws -> Bool {
+        if #available(macOS 14.0, *) {
+            return try await store.requestFullAccessToReminders()
+        } else {
+            return try await withCheckedThrowingContinuation { continuation in
+                store.requestAccess(to: .reminder) { granted, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: granted)
+                    }
+                }
+            }
+        }
+    }
+
+    private func reminderCalendar(matching identifier: String?) -> EKCalendar? {
+        if let identifier,
+           let calendar = store.calendar(withIdentifier: identifier),
+           calendar.allowedEntityTypes.contains(.reminder) {
+            return calendar
+        }
+        return store.defaultCalendarForNewReminders()
     }
 }
 

--- a/Services/NotificationScheduler.swift
+++ b/Services/NotificationScheduler.swift
@@ -4,7 +4,7 @@ import os.log
 #endif
 
 struct Reminder {
-    let text: String
+    let title: String
     let dueDate: Date?
 }
 
@@ -15,9 +15,9 @@ protocol NotificationScheduling {
 final class NotificationScheduler: NotificationScheduling {
     func schedule(_ reminder: Reminder) {
 #if canImport(os)
-        os_log("schedule %{public}@", log: .notifications, type: .info, reminder.text)
+        os_log("Scheduled local notification due_date_present=%{public}@", log: .notifications, type: .info, reminder.dueDate == nil ? "false" : "true")
 #else
-        print("schedule \(reminder.text)")
+        print("schedule")
 #endif
     }
 }

--- a/Services/RemindersAPI.swift
+++ b/Services/RemindersAPI.swift
@@ -1,17 +1,26 @@
 import Foundation
 
+struct ReminderList: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+}
+
 protocol RemindersAPI: Sendable {
-    func createReminder(text: String, dueDate: Date?) async throws
+    func createReminder(title: String, dueDate: Date?, calendarIdentifier: String?) async throws
+}
+
+protocol ReminderListProviding: Sendable {
+    func reminderLists() async throws -> [ReminderList]
 }
 
 actor MockRemindersAPI: RemindersAPI {
-    private var created: [(text: String, dueDate: Date?)] = []
+    private var created: [(title: String, dueDate: Date?, calendarIdentifier: String?)] = []
 
-    func createReminder(text: String, dueDate: Date?) async throws {
-        created.append((text: text, dueDate: dueDate))
+    func createReminder(title: String, dueDate: Date?, calendarIdentifier: String?) async throws {
+        created.append((title: title, dueDate: dueDate, calendarIdentifier: calendarIdentifier))
     }
 
-    var createdReminders: [(text: String, dueDate: Date?)] {
+    var createdReminders: [(title: String, dueDate: Date?, calendarIdentifier: String?)] {
         get async {
             return created
         }

--- a/Services/SettingsStore.swift
+++ b/Services/SettingsStore.swift
@@ -3,13 +3,61 @@ import Foundation
 final class SettingsStore: ObservableObject {
     private enum Keys: String {
         case syncEnabled
+        case notificationsEnabled
+        case defaultReminderListIdentifier
+        case defaultTimeHour
+        case defaultTimeMinute
     }
 
-    @Published var syncEnabled: Bool {
-        didSet { UserDefaults.standard.set(syncEnabled, forKey: Keys.syncEnabled.rawValue) }
+    private let defaults: UserDefaults
+
+    @Published var notificationsEnabled: Bool {
+        didSet { defaults.set(notificationsEnabled, forKey: Keys.notificationsEnabled.rawValue) }
     }
 
-    init() {
-        syncEnabled = UserDefaults.standard.object(forKey: Keys.syncEnabled.rawValue) as? Bool ?? true
+    @Published var defaultReminderListIdentifier: String? {
+        didSet {
+            if let defaultReminderListIdentifier {
+                defaults.set(defaultReminderListIdentifier, forKey: Keys.defaultReminderListIdentifier.rawValue)
+            } else {
+                defaults.removeObject(forKey: Keys.defaultReminderListIdentifier.rawValue)
+            }
+        }
+    }
+
+    @Published var defaultTime: Date {
+        didSet {
+            let components = Calendar.current.dateComponents([.hour, .minute], from: defaultTime)
+            defaults.set(components.hour ?? 9, forKey: Keys.defaultTimeHour.rawValue)
+            defaults.set(components.minute ?? 0, forKey: Keys.defaultTimeMinute.rawValue)
+        }
+    }
+
+    var defaultTimeComponents: DateComponents {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: defaultTime)
+        return DateComponents(hour: components.hour ?? 9, minute: components.minute ?? 0, second: 0)
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        if defaults.object(forKey: Keys.notificationsEnabled.rawValue) == nil,
+           let legacyValue = defaults.object(forKey: Keys.syncEnabled.rawValue) as? Bool {
+            defaults.set(legacyValue, forKey: Keys.notificationsEnabled.rawValue)
+        }
+
+        notificationsEnabled = defaults.object(forKey: Keys.notificationsEnabled.rawValue) as? Bool ?? true
+        defaultReminderListIdentifier = defaults.string(forKey: Keys.defaultReminderListIdentifier.rawValue)
+
+        let hour = defaults.object(forKey: Keys.defaultTimeHour.rawValue) as? Int ?? 9
+        let minute = defaults.object(forKey: Keys.defaultTimeMinute.rawValue) as? Int ?? 0
+        defaultTime = SettingsStore.makeTime(hour: hour, minute: minute)
+    }
+
+    private static func makeTime(hour: Int, minute: Int) -> Date {
+        let safeHour = min(max(hour, 0), 23)
+        let safeMinute = min(max(minute, 0), 59)
+        let components = DateComponents(year: 2001, month: 1, day: 1, hour: safeHour, minute: safeMinute)
+        return Calendar.current.date(from: components) ?? Date(timeIntervalSinceReferenceDate: 0)
     }
 }

--- a/SlashRemindApp.swift
+++ b/SlashRemindApp.swift
@@ -6,7 +6,7 @@ struct SlashRemindApp: App {
     
     var body: some Scene {
         Settings {
-            PreferencesWindow(settings: appDelegate.settings)
+            PreferencesWindow(settings: appDelegate.settings, listProvider: appDelegate.remindersService)
         }
     }
 }

--- a/SlashRemindTests/DateParsingServiceTests.swift
+++ b/SlashRemindTests/DateParsingServiceTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class DateParsingServiceTests: XCTestCase {
     var parser: DateParsing!
+    let defaultTime = DateComponents(hour: 9, minute: 0, second: 0)
 
     override func setUp() {
         super.setUp()
@@ -10,7 +11,7 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testParsesTomorrowAt9AM() {
-        let result = parser.parseDate(from: "tomorrow at 9am")
+        let result = parser.parseDate(from: "tomorrow at 9am", defaultTime: defaultTime)
         XCTAssertNotNil(result)
 
         guard let date = result else { return }
@@ -21,7 +22,7 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testParsesNextMondayAt3PM() {
-        let result = parser.parseDate(from: "next Monday 3pm")
+        let result = parser.parseDate(from: "next Monday 3pm", defaultTime: defaultTime)
         XCTAssertNotNil(result)
 
         guard let date = result else { return }
@@ -32,7 +33,7 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testDateOnlyApplies9AMDefault() {
-        let result = parser.parseDate(from: "tomorrow")
+        let result = parser.parseDate(from: "tomorrow", defaultTime: defaultTime)
         XCTAssertNotNil(result)
 
         guard let date = result else { return }
@@ -44,7 +45,7 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testParsesMarch15WithDefault9AM() {
-        let result = parser.parseDate(from: "March 15")
+        let result = parser.parseDate(from: "March 15", defaultTime: defaultTime)
         XCTAssertNotNil(result)
 
         guard let date = result else { return }
@@ -57,7 +58,7 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testParsesRelativeTime() {
-        let result = parser.parseDate(from: "in 3 hours")
+        let result = parser.parseDate(from: "in 3 hours", defaultTime: defaultTime)
         XCTAssertNotNil(result)
 
         guard let date = result else { return }
@@ -68,12 +69,23 @@ final class DateParsingServiceTests: XCTestCase {
     }
 
     func testReturnsNilForInvalidInput() {
-        let result = parser.parseDate(from: "xyz invalid")
+        let result = parser.parseDate(from: "xyz invalid", defaultTime: defaultTime)
         XCTAssertNil(result)
     }
 
     func testReturnsNilForEmptyString() {
-        let result = parser.parseDate(from: "")
+        let result = parser.parseDate(from: "", defaultTime: defaultTime)
         XCTAssertNil(result)
+    }
+
+    func testDateOnlyUsesConfiguredDefaultTime() {
+        let result = parser.parseDate(from: "tomorrow", defaultTime: DateComponents(hour: 14, minute: 30, second: 0))
+        XCTAssertNotNil(result)
+
+        guard let date = result else { return }
+        let components = Calendar.current.dateComponents([.hour, .minute, .second], from: date)
+        XCTAssertEqual(components.hour, 14)
+        XCTAssertEqual(components.minute, 30)
+        XCTAssertEqual(components.second, 0)
     }
 }

--- a/SlashRemindTests/PaletteViewModelTests.swift
+++ b/SlashRemindTests/PaletteViewModelTests.swift
@@ -17,49 +17,46 @@ final class PaletteViewModelTests: XCTestCase {
         let mockAPI = MockRemindersAPI()
         let mockScheduler = MockNotificationScheduler()
         let fixedDate = Date(timeIntervalSince1970: 1704110400)
-        let mockDateParser = MockDateParser(fixedDate: fixedDate)
-        let settings = SettingsStore()
+        let mockInputParser = MockInputParser(parsed: ParsedReminderInput(title: "Buy milk", dueDate: fixedDate))
+        let settings = SettingsStore(defaults: isolatedDefaults())
 
         let vm = await PaletteViewModel(
             api: mockAPI,
             settings: settings,
             scheduler: mockScheduler,
-            dateParser: mockDateParser
+            inputParser: mockInputParser
         )
 
         await vm.setText("Buy milk tomorrow")
         await vm.submit()
 
-        try await Task.sleep(nanoseconds: 100_000_000)
-
         let reminders = await mockAPI.createdReminders
         XCTAssertEqual(reminders.count, 1)
-        XCTAssertEqual(reminders.first?.text, "Buy milk tomorrow")
+        XCTAssertEqual(reminders.first?.title, "Buy milk")
         XCTAssertEqual(reminders.first?.dueDate, fixedDate)
+        XCTAssertNil(reminders.first?.calendarIdentifier)
 
         let scheduled = await mockScheduler.scheduledReminders
         XCTAssertEqual(scheduled.count, 1)
-        XCTAssertEqual(scheduled.first?.text, "Buy milk tomorrow")
+        XCTAssertEqual(scheduled.first?.title, "Buy milk")
         XCTAssertEqual(scheduled.first?.dueDate, fixedDate)
     }
 
     func testSubmitWithNilDateShowsErrorAndDoesNotCreateReminder() async throws {
         let mockAPI = MockRemindersAPI()
         let mockScheduler = MockNotificationScheduler()
-        let mockDateParser = MockDateParser(fixedDate: nil)
-        let settings = SettingsStore()
+        let mockInputParser = MockInputParser(parsed: nil)
+        let settings = SettingsStore(defaults: isolatedDefaults())
 
         let vm = await PaletteViewModel(
             api: mockAPI,
             settings: settings,
             scheduler: mockScheduler,
-            dateParser: mockDateParser
+            inputParser: mockInputParser
         )
 
         await vm.setText("Buy milk")
         await vm.submit()
-
-        try await Task.sleep(nanoseconds: 100_000_000)
 
         let error = await vm.getError()
         XCTAssertNotNil(error)
@@ -71,6 +68,40 @@ final class PaletteViewModelTests: XCTestCase {
 
         let scheduled = await mockScheduler.scheduledReminders
         XCTAssertEqual(scheduled.count, 0)
+    }
+
+    func testSubmitUsesSelectedReminderListAndSkipsNotificationsWhenDisabled() async throws {
+        let mockAPI = MockRemindersAPI()
+        let mockScheduler = MockNotificationScheduler()
+        let fixedDate = Date(timeIntervalSince1970: 1704110400)
+        let settings = SettingsStore(defaults: isolatedDefaults())
+        await MainActor.run {
+            settings.defaultReminderListIdentifier = "calendar-id"
+            settings.notificationsEnabled = false
+        }
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: ParsedReminderInput(title: "Pay rent", dueDate: fixedDate))
+        )
+
+        await vm.setText("Pay rent tomorrow")
+        await vm.submit()
+
+        let reminders = await mockAPI.createdReminders
+        XCTAssertEqual(reminders.first?.calendarIdentifier, "calendar-id")
+
+        let scheduled = await mockScheduler.scheduledReminders
+        XCTAssertTrue(scheduled.isEmpty)
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "PaletteViewModelTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
     }
 }
 
@@ -85,15 +116,15 @@ extension PaletteViewModel {
     }
 }
 
-final class MockDateParser: DateParsing, @unchecked Sendable {
-    private let fixedDate: Date?
+final class MockInputParser: ReminderInputParsing, @unchecked Sendable {
+    private let parsed: ParsedReminderInput?
 
-    init(fixedDate: Date?) {
-        self.fixedDate = fixedDate
+    init(parsed: ParsedReminderInput?) {
+        self.parsed = parsed
     }
 
-    func parseDate(from text: String) -> Date? {
-        return fixedDate
+    func parse(_ text: String, defaultTime: DateComponents) -> ParsedReminderInput? {
+        parsed
     }
 }
 

--- a/SlashRemindTests/RemindersAPITests.swift
+++ b/SlashRemindTests/RemindersAPITests.swift
@@ -4,10 +4,10 @@ import XCTest
 final class RemindersAPITests: XCTestCase {
     func testMockRemindersAPIBasic() async throws {
         let mockAPI = MockRemindersAPI()
-        try await mockAPI.createReminder(text: "Test reminder", dueDate: nil)
+        try await mockAPI.createReminder(title: "Test reminder", dueDate: nil, calendarIdentifier: nil)
         let reminders = await mockAPI.createdReminders
         XCTAssertEqual(reminders.count, 1)
-        XCTAssertEqual(reminders.first?.text, "Test reminder")
+        XCTAssertEqual(reminders.first?.title, "Test reminder")
         XCTAssertNil(reminders.first?.dueDate)
     }
 }

--- a/SlashRemindTests/SlashRemindTests.swift
+++ b/SlashRemindTests/SlashRemindTests.swift
@@ -1,17 +1,111 @@
-//
-//  SlashRemindTests.swift
-//  SlashRemindTests
-//
-//  Created by Maurice Le Cordier on 2025/09/02.
-//
-
-import Testing
+import XCTest
 @testable import SlashRemind
 
-struct SlashRemindTests {
+final class QuickAddInputParserTests: XCTestCase {
+    private let dueDate = Date(timeIntervalSince1970: 1_704_110_400)
+    private let defaultTime = DateComponents(hour: 9, minute: 0, second: 0)
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testStripsDateAndTimeFromTitle() {
+        let parser = QuickAddInputParser(dateParser: ControlledDateParser(matches: [
+            "buy milk tomorrow at 9am": dueDate,
+            "tomorrow at 9am": dueDate
+        ]))
+
+        let result = parser.parse("buy milk tomorrow at 9am", defaultTime: defaultTime)
+
+        XCTAssertEqual(result?.title, "buy milk")
+        XCTAssertEqual(result?.dueDate, dueDate)
     }
 
+    func testStripsDateOnlySuffixFromTitle() {
+        let parser = QuickAddInputParser(dateParser: ControlledDateParser(matches: [
+            "file taxes tomorrow": dueDate,
+            "tomorrow": dueDate
+        ]))
+
+        let result = parser.parse("file taxes tomorrow", defaultTime: defaultTime)
+
+        XCTAssertEqual(result?.title, "file taxes")
+        XCTAssertEqual(result?.dueDate, dueDate)
+    }
+
+    func testStripsTimeOnlySuffixFromTitle() {
+        let parser = QuickAddInputParser(dateParser: ControlledDateParser(matches: [
+            "call mom at 9am": dueDate,
+            "at 9am": dueDate
+        ]))
+
+        let result = parser.parse("call mom at 9am", defaultTime: defaultTime)
+
+        XCTAssertEqual(result?.title, "call mom")
+        XCTAssertEqual(result?.dueDate, dueDate)
+    }
+
+    func testDateOnlyInputFallsBackToGenericTitle() {
+        let parser = QuickAddInputParser(dateParser: ControlledDateParser(matches: [
+            "tomorrow": dueDate
+        ]))
+
+        let result = parser.parse("tomorrow", defaultTime: defaultTime)
+
+        XCTAssertEqual(result?.title, "Reminder")
+        XCTAssertEqual(result?.dueDate, dueDate)
+    }
+
+    func testStripsPrepositionBeforeDate() {
+        let parser = QuickAddInputParser(dateParser: ControlledDateParser(matches: [
+            "book flights on March 15": dueDate,
+            "on March 15": dueDate
+        ]))
+
+        let result = parser.parse("book flights on March 15", defaultTime: defaultTime)
+
+        XCTAssertEqual(result?.title, "book flights")
+        XCTAssertEqual(result?.dueDate, dueDate)
+    }
+}
+
+@MainActor
+final class SettingsStoreTests: XCTestCase {
+    func testMigratesLegacySyncEnabledPreference() {
+        let defaults = isolatedDefaults()
+        defaults.set(false, forKey: "syncEnabled")
+
+        let settings = SettingsStore(defaults: defaults)
+
+        XCTAssertFalse(settings.notificationsEnabled)
+        XCTAssertFalse(defaults.bool(forKey: "notificationsEnabled"))
+    }
+
+    func testPersistsDefaultReminderListAndDefaultTime() {
+        let defaults = isolatedDefaults()
+        let settings = SettingsStore(defaults: defaults)
+
+        settings.defaultReminderListIdentifier = "list-id"
+        settings.defaultTime = Calendar.current.date(from: DateComponents(year: 2001, month: 1, day: 1, hour: 16, minute: 45))!
+
+        let reloaded = SettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.defaultReminderListIdentifier, "list-id")
+        XCTAssertEqual(reloaded.defaultTimeComponents.hour, 16)
+        XCTAssertEqual(reloaded.defaultTimeComponents.minute, 45)
+    }
+
+    private func isolatedDefaults() -> UserDefaults {
+        let suiteName = "SlashRemindTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+private final class ControlledDateParser: DateParsing, @unchecked Sendable {
+    private let matches: [String: Date]
+
+    init(matches: [String: Date]) {
+        self.matches = matches
+    }
+
+    func parseDate(from text: String, defaultTime: DateComponents) -> Date? {
+        matches[text.trimmingCharacters(in: .whitespacesAndNewlines)]
+    }
 }

--- a/SlashRemindUITests/SlashRemindUITests.swift
+++ b/SlashRemindUITests/SlashRemindUITests.swift
@@ -1,41 +1,22 @@
-//
-//  SlashRemindUITests.swift
-//  SlashRemindUITests
-//
-//  Created by Maurice Le Cordier on 2025/09/02.
-//
-
 import XCTest
 
 final class SlashRemindUITests: XCTestCase {
-
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testQuickAddPaletteShowsAndDismissesWithEscape() throws {
         let app = XCUIApplication()
+        app.launchEnvironment["SLASH_REMIND_SHOW_PALETTE_ON_LAUNCH"] = "1"
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+        let textField = app.textFields["quickAddTextField"]
+        XCTAssertTrue(textField.waitForExistence(timeout: 5))
+        textField.typeText("buy milk tomorrow at 9am")
+        XCTAssertEqual(textField.value as? String, "buy milk tomorrow at 9am")
 
-    @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
-        }
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertFalse(textField.waitForExistence(timeout: 1))
     }
 }

--- a/SlashRemindUITests/SlashRemindUITestsLaunchTests.swift
+++ b/SlashRemindUITests/SlashRemindUITestsLaunchTests.swift
@@ -21,13 +21,6 @@ final class SlashRemindUITestsLaunchTests: XCTestCase {
     func testLaunch() throws {
         let app = XCUIApplication()
         app.launch()
-
-        // Insert steps here to perform after app launch but before taking a screenshot,
-        // such as logging into a test account or navigating somewhere in the app
-
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
-        add(attachment)
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 3) || app.wait(for: .runningBackground, timeout: 3))
     }
 }

--- a/StatusBar/StatusBarController.swift
+++ b/StatusBar/StatusBarController.swift
@@ -16,19 +16,19 @@ final class StatusBarController {
 
     private func constructMenu() {
         if let button = statusItem.button {
-            let symbol = settings.syncEnabled ? "bolt.horizontal.circle" : "bolt.slash.circle"
+            let symbol = settings.notificationsEnabled ? "bell.circle" : "bell.slash.circle"
             button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
         }
         let menu = NSMenu()
         
-        let paletteItem = NSMenuItem(title: "Open Command Palette", action: #selector(openPalette), keyEquivalent: "")
+        let paletteItem = NSMenuItem(title: "Open Quick Add", action: #selector(openPalette), keyEquivalent: "")
         paletteItem.target = self
         menu.addItem(paletteItem)
         
-        let syncTitle = settings.syncEnabled ? "Pause Sync" : "Resume Sync"
-        let syncItem = NSMenuItem(title: syncTitle, action: #selector(toggleSync), keyEquivalent: "")
-        syncItem.target = self
-        menu.addItem(syncItem)
+        let notificationTitle = settings.notificationsEnabled ? "Disable Notifications" : "Enable Notifications"
+        let notificationItem = NSMenuItem(title: notificationTitle, action: #selector(toggleNotifications), keyEquivalent: "")
+        notificationItem.target = self
+        menu.addItem(notificationItem)
         
         menu.addItem(NSMenuItem.separator())
         
@@ -52,8 +52,8 @@ final class StatusBarController {
         NSApp.sendAction(#selector(AppDelegate.openPreferences(_:)), to: nil, from: nil)
     }
 
-    @objc private func toggleSync() {
-        settings.syncEnabled.toggle()
+    @objc private func toggleNotifications() {
+        settings.notificationsEnabled.toggle()
         constructMenu()
     }
 

--- a/ViewModels/PaletteViewModel.swift
+++ b/ViewModels/PaletteViewModel.swift
@@ -6,20 +6,21 @@ final class PaletteViewModel: ObservableObject {
     @Published var isSubmitting = false
     @Published var error: String?
     @Published var didCreateReminder = false
+    @Published var focusRequestID = 0
 
     private let api: RemindersAPI
     private let settings: SettingsStore
     private let scheduler: NotificationScheduling
-    private let dateParser: DateParsing
+    private let inputParser: ReminderInputParsing
 
-    init(api: RemindersAPI, settings: SettingsStore, scheduler: NotificationScheduling, dateParser: DateParsing) {
+    init(api: RemindersAPI, settings: SettingsStore, scheduler: NotificationScheduling, inputParser: ReminderInputParsing) {
         self.api = api
         self.settings = settings
         self.scheduler = scheduler
-        self.dateParser = dateParser
+        self.inputParser = inputParser
     }
 
-    func submit() {
+    func submit() async {
         let message = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else {
             error = "Type a reminder with a date or time"
@@ -30,25 +31,33 @@ final class PaletteViewModel: ObservableObject {
         didCreateReminder = false
         error = nil
 
-        guard let parsedDate = dateParser.parseDate(from: message) else {
+        guard let parsed = inputParser.parse(message, defaultTime: settings.defaultTimeComponents) else {
             self.error = "Please include a date or time (e.g., 'tomorrow at 9am')"
             self.isSubmitting = false
             return
         }
 
-        Task {
-            do {
-                try await api.createReminder(text: message, dueDate: parsedDate)
-                scheduler.schedule(Reminder(text: message, dueDate: parsedDate))
-                self.didCreateReminder = true
-                self.isSubmitting = false
-                self.error = nil
-            } catch {
-                self.error = "Couldn’t create reminder. Please try again."
-                self.isSubmitting = false
-                self.didCreateReminder = false
+        do {
+            try await api.createReminder(
+                title: parsed.title,
+                dueDate: parsed.dueDate,
+                calendarIdentifier: settings.defaultReminderListIdentifier
+            )
+            if settings.notificationsEnabled {
+                scheduler.schedule(Reminder(title: parsed.title, dueDate: parsed.dueDate))
             }
+            self.didCreateReminder = true
+            self.isSubmitting = false
+            self.error = nil
+        } catch {
+            self.error = "Couldn’t create reminder. Please try again."
+            self.isSubmitting = false
+            self.didCreateReminder = false
         }
+    }
+
+    func requestFocus() {
+        focusRequestID += 1
     }
 
     func reset() {

--- a/prompt-guide.md
+++ b/prompt-guide.md
@@ -1,0 +1,264 @@
+# GPT-5.5 prompting guide
+
+Prompt GPT-5.5 with outcome-first goals, concise style controls, retrieval budgets, and validation loops.
+
+## New in GPT-5.5 vs GPT-5.4
+- Shorter, outcome-first prompts usually work better than process-heavy prompt stacks.
+- More efficient reasoning means `low` and `medium` effort should be re-evaluated before escalating.
+- Preambles, `phase` handling, and assistant-item replay remain important for tool-heavy Responses workflows.
+- Explicit personality, retrieval budgets, and validation rules help shape customer-facing and agentic UX.
+
+GPT-5.5 works best when prompts define the outcome and leave room for the model to choose an efficient solution path. Compared with earlier models, you can often use shorter, more outcome-oriented prompts: describe what good looks like, what constraints matter, what evidence is available, and what the final answer should contain.
+
+Avoid carrying over every instruction from an older prompt stack. Legacy prompts often over-specify the process because earlier models needed more help staying on track. With GPT-5.5, that can add noise, narrow the model's search space, or lead to overly mechanical answers.
+
+For more detail on GPT-5.5 behavior changes, start with the [Using GPT-5.5 guide](https://developers.openai.com/api/docs/guides/latest-model). This guide focuses on prompt changes that follow from those behavior changes.
+
+The patterns here are starting points. Adapt them to your product surface, tools, evals, and user experience goals.
+
+## Automated migration with Codex
+
+Codex can implement the changes from this guide with the [OpenAI Docs Skill](https://github.com/openai/skills/tree/main/skills/.curated/openai-docs).
+
+```text
+$openai-docs migrate this project to gpt-5.5
+```
+
+To use this skill in other coding agents, download it from the [OpenAI skills repository](https://github.com/openai/skills/tree/main/skills/.curated/openai-docs).
+
+## Personality and behavior
+
+GPT-5.5's default style is efficient, direct, and task-oriented. This is useful for production systems: responses stay focused, behavior is easier to steer, and the model avoids unnecessary conversational padding.
+
+For customer-facing assistants, support workflows, coaching experiences, and other conversational products, define both personality and collaboration style.
+
+- **Personality** controls how the assistant sounds: tone, warmth, directness, formality, humor, empathy, and level of polish.
+- **Collaboration style** controls how the assistant works: when it asks questions, when it makes assumptions, how proactive it should be, how much context it gives, when it checks work, and how it handles uncertainty or risk.
+
+Keep both short. Personality instructions should shape the user experience. Collaboration instructions should shape task behavior. Neither should replace clear goals, success criteria, tool rules, or stopping conditions.
+
+Example personality block for a steady task-focused assistant:
+
+```text
+# Personality
+You are a capable collaborator: approachable, steady, and direct. Assume the user is competent and acting in good faith, and respond with patience, respect, and practical helpfulness.
+
+Prefer making progress over stopping for clarification when the request is already clear enough to attempt. Use context and reasonable assumptions to move forward. Ask for clarification only when the missing information would materially change the answer or create meaningful risk, and keep any question narrow.
+
+Stay concise without becoming curt. Give enough context for the user to understand and trust the answer, then stop. Use examples, comparisons, or simple analogies when they make the point easier to grasp. When correcting the user or disagreeing, be candid but constructive. When an error is pointed out, acknowledge it plainly and focus on fixing it.
+
+Match the user's tone within professional bounds. Avoid emojis and profanity by default, unless the user explicitly asks for that style or has clearly established it as appropriate for the conversation.
+```
+
+Example personality block for an expressive collaborative assistant:
+
+```text
+# Personality
+Adopt a vivid conversational presence: intelligent, curious, playful when appropriate, and attentive to the user's thinking. Ask good questions when the problem is blurry, then become decisive once there is enough context.
+
+Be warm, collaborative, and polished. Conversation should feel easy and alive, but not chatty for its own sake. Offer a real point of view rather than merely mirroring the user, while staying responsive to their goals and constraints.
+
+Be thoughtful and grounded when the task calls for synthesis or advice. State a clear recommendation when you have enough context, explain important tradeoffs, and name uncertainty without becoming evasive.
+```
+
+For more expressive products, add warmth, curiosity, humor, or point of view explicitly, but keep the block short. Use personality to shape the experience, not to compensate for unclear goals or missing task instructions.
+
+## Improve time to first visible token with a preamble
+
+In streaming applications, users notice how long it takes before the first visible response appears. GPT-5.5 may spend time reasoning, planning, or preparing tool calls before emitting visible text.
+
+For longer or tool-heavy tasks, prompt the model to start with a short preamble: a brief visible update that acknowledges the request and states the first step. This can improve perceived responsiveness without changing the underlying task.
+
+Use this pattern when the task may take more than one step, require tool calls, or involve a long-running agent workflow.
+
+```text
+Before any tool calls for a multi-step task, send a short user-visible update that acknowledges the request and states the first step. Keep it to one or two sentences.
+```
+
+For coding agents that expose separate message phases, you can be more explicit:
+
+```text
+You must always start with an intermediary update before any content in the analysis channel if the task will require calling tools. The user update should acknowledge the request and explain your first step.
+```
+
+## Outcome-first prompts and stopping conditions
+
+GPT-5.5 is strongest when the prompt defines the target outcome, success criteria, constraints, and available context, then lets the model choose the path.
+
+For many tasks, describe the destination rather than every step. This gives the model room to choose the right search, tool, or reasoning strategy for the task.
+
+Prefer this:
+
+```text
+Resolve the customer's issue end to end.
+
+Success means:
+- the eligibility decision is made from the available policy and account data
+- any allowed action is completed before responding
+- the final answer includes completed_actions, customer_message, and blockers
+- if evidence is missing, ask for the smallest missing field
+```
+
+**Avoid unnecessary absolute rules.** Older prompts often use strict instructions like `ALWAYS`, `NEVER`, `must`, and `only` to control model behavior. Use those words for true invariants, such as safety rules, required output fields, or actions that should never happen. For judgment calls, such as when to search, ask for clarification, use a tool, or keep iterating, prefer decision rules instead.
+
+Avoid this style of instruction unless every step is truly required:
+
+```text
+First inspect A, then inspect B, then compare every field, then think through
+all possible exceptions, then decide which tool to call, then call the tool,
+then explain the entire process to the user.
+```
+
+Add explicit stopping conditions:
+
+```text
+Resolve the user query in the fewest useful tool loops, but do not let loop minimization outrank correctness, accessible fallback evidence, calculations, or required citation tags for factual claims.
+
+After each result, ask: "Can I answer the user's core request now with useful evidence and citations for the factual claims?" If yes, answer.
+```
+
+Define missing-evidence behavior:
+
+```text
+Use the minimum evidence sufficient to answer correctly, cite it precisely, then stop.
+```
+
+## Formatting
+
+GPT-5.5 is highly steerable on output format and structure. Use that control when it improves comprehension or product fit.
+
+Set `text.verbosity`, describe the expected output shape, and reserve heavier structure for cases where it improves comprehension or your product UI needs a stable artifact. The API default for `text.verbosity` is `medium`; use `low` when you prefer shorter, more concise responses.
+
+Plain conversational formatting:
+
+```text
+Let formatting serve comprehension. Use plain paragraphs as the default format for normal conversation, explanations, reports, documentation, and technical writeups. Keep the presentation clean and readable without making the structure feel heavier than the content.
+
+Use headers, bold text, bullets, and numbered lists sparingly. Reach for them when the user requests them, when the answer needs clear comparison or ranking, or when the information would be harder to scan as prose. Otherwise, favor short paragraphs and natural transitions.
+
+Respect formatting preferences from the user. If they ask for a terse answer, minimal formatting, no bullets, no headers, or a specific structure, follow that preference unless there is a strong reason not to.
+```
+
+Add explicit audience and length guidance:
+
+```text
+Write for a senior business audience. Keep the answer under 400 words. Use short paragraphs and only include bullets when they improve scannability. Prioritize the conclusion first, then the reasoning, then caveats.
+```
+
+For editing, rewriting, summaries, or customer-facing messages, tell the model what to preserve before asking it to improve style. This pattern is useful when you want polish without expansion.
+
+```text
+Preserve the requested artifact, length, structure, and genre first. Quietly improve clarity, flow, and correctness. Do not add new claims, extra sections, or a more promotional tone unless explicitly requested.
+```
+
+## Grounding, citations, and retrieval budgets
+
+For grounded answers, citation behavior should be part of the prompt. Define what needs support, what counts as enough evidence, and how the model should behave when evidence is missing. Absence of evidence shouldn't automatically become a factual "no." For more details and examples, see the [citation formatting guide](https://developers.openai.com/api/docs/guides/citation-formatting).
+
+### Add an explicit retrieval budget
+
+Retrieval budgets are stopping rules for search. They tell the model when enough evidence is enough.
+
+```text
+For ordinary Q&A, start with one broad search using short, discriminative keywords. If the top results contain enough citable support for the core request, answer from those results instead of searching again.
+
+Make another retrieval call only when:
+- The top results do not answer the core question.
+- A required fact, parameter, owner, date, ID, or source is missing.
+- The user asked for exhaustive coverage, a comparison, or a comprehensive list.
+- A specific document, URL, email, meeting, record, or code artifact must be read.
+- The answer would otherwise contain an important unsupported factual claim.
+
+Do not search again to improve phrasing, add examples, cite nonessential details, or support wording that can safely be made more generic.
+```
+
+## Creative drafting guardrails
+
+For drafting tasks, tell the model which claims must come from sources and which parts may be creatively written. This is especially important for slides, launch copy, customer summaries, talk tracks, leadership blurbs, and narrative framing.
+
+```text
+For creative or generative requests such as slides, leadership blurbs, outbound copy, summaries for sharing, talk tracks, or narrative framing, distinguish source-backed facts from creative wording.
+
+- Use retrieved or provided facts for concrete product, customer, metric, roadmap, date, capability, and competitive claims, and cite those claims.
+- Do not invent specific names, first-party data claims, metrics, roadmap status, customer outcomes, or product capabilities to make the draft sound stronger.
+- If there is little or no citable support, write a useful generic draft with placeholders or clearly labeled assumptions rather than unsupported specifics.
+```
+
+## Frontend engineering and visual taste
+
+For frontend work, refer to the [example instructions](https://developers.openai.com/api/docs/guides/frontend-prompt) for practical ways to steer UI quality. They cover product and user context, design-system alignment, first-screen usability, familiar controls, expected states, responsive behavior, and common generated-UI defaults to avoid, such as generic heroes, nested cards, decorative gradients, visible instructional text, and broken layouts.
+
+## Prompt the model to check its work
+
+Give GPT-5.5 access to tools that let it check outputs when validation is possible.
+
+For coding agents, ask for concrete validation commands:
+
+```text
+After making changes, run the most relevant validation available:
+- targeted unit tests for changed behavior
+- type checks or lint checks when applicable
+- build checks for affected packages
+- a minimal smoke test when full validation is too expensive
+
+If validation cannot be run, explain why and describe the next best check.
+```
+
+For visual artifacts, ask for inspection after rendering:
+
+```text
+Render the artifact before finalizing. Inspect the rendered output for layout, clipping, spacing, missing content, and visual consistency. Revise until the rendered output matches the requirements.
+```
+
+For engineering and planning tasks, make implementation plans traceable:
+
+```text
+For implementation plans, include:
+- requirements and where each is addressed
+- named resources, files, APIs, or systems involved
+- state transitions or data flow where relevant
+- validation commands or checks
+- failure behavior
+- privacy and security considerations
+- open questions that materially affect implementation
+```
+
+## Phase parameter
+
+Starting with GPT-5.4, long-running or tool-heavy Responses workflows can use assistant-item `phase` values to distinguish intermediate updates from final answers. GPT-5.5 uses the same pattern.
+
+If you use `previous_response_id`, the API preserves prior assistant state automatically. If your application manually replays assistant output items into the next request, preserve each original `phase` value and pass it back unchanged. This matters most when a response includes preambles, repeated tool calls, or a final answer after intermediate assistant updates.
+
+```text
+If manually replaying assistant items:
+- Preserve assistant `phase` values exactly.
+- Use `phase: "commentary"` for intermediate user-visible updates.
+- Use `phase: "final_answer"` for the completed answer.
+- Do not add `phase` to user messages.
+```
+
+## Suggested prompt structure
+
+Use this structure as a starting point for complex prompts. Keep each section short. Add detail only where it changes behavior.
+
+```text
+Role: [1-2 sentences defining the model's function, context, and job]
+
+# Personality
+[tone, demeanor, and collaboration style]
+
+# Goal
+[user-visible outcome]
+
+# Success criteria
+[what must be true before the final answer]
+
+# Constraints
+[policy, safety, business, evidence, and side-effect limits]
+
+# Output
+[sections, length, and tone]
+
+# Stop rules
+[when to retry, fallback, abstain, ask, or stop]
+```


### PR DESCRIPTION
 Implemented the quick-add polish end to end.

  Changed:

  - Added quick-add parsing that creates cleaned titles like buy milk from buy milk tomorrow at 9am, while preserving parsed due dates.
  - Added configurable default time and default Reminders list, with fallback to EventKit’s default list if the saved list is unavailable.
  - Renamed syncEnabled to notificationsEnabled with UserDefaults migration from the old key.
  - Made the palette more transient: Escape hides it, focus/app deactivation hides it, focus is re-requested on every open, and centering uses the active/mouse screen.
  - Removed reminder content from logs; logs now only emit metadata.
  - Replaced placeholder tests with real unit/UI coverage.

  Important files touched:

  - Services/DateParsingService.swift
  - ViewModels/PaletteViewModel.swift
  - Services/EventKitRemindersService.swift
  - Services/SettingsStore.swift
  - Preferences/PreferencesWindow.swift
  - Palette/CommandPaletteWindowController.swift
  - SlashRemindTests/*
  - SlashRemindUITests/*

  Validation:

  - make test passed.
  - This built the app, unit tests, and UI tests, so I did not run a separate make build.

  Remaining limitation: title stripping is intentionally focused on recognized date/time suffixes and common preposition forms, not arbitrary date phrases embedded anywhere in
  the sentence. prompt-guide.md was already present in the worktree and I left it untouched.