### PR TITLE
update the design of the command pallete to match mock image

### DIFF
--- a/Palette/CommandPaletteView.swift
+++ b/Palette/CommandPaletteView.swift
@@ -30,21 +30,26 @@ struct CommandPaletteView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             inputRow
-            feedbackRow
             footer
         }
-        .padding(14)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
         .frame(width: 520)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(.regularMaterial)
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(.ultraThinMaterial)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(Color.black.opacity(0.24))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .stroke(.white.opacity(0.16), lineWidth: 0.8)
                 )
-                .shadow(color: .black.opacity(0.16), radius: 14, x: 0, y: 6)
+                .shadow(color: .black.opacity(0.22), radius: 18, x: 0, y: 8)
         )
         .background(KeyEventHandling(onEscape: onDismiss))
+        .preferredColorScheme(.dark)
         .onAppear {
             focusTextField()
         }
@@ -74,10 +79,20 @@ struct CommandPaletteView: View {
     }
 
     private var inputRow: some View {
-        HStack(spacing: 10) {
-            Image(systemName: viewModel.didCreateReminder ? "checkmark.circle.fill" : "calendar")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(viewModel.didCreateReminder ? Color.green : Color.secondary)
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(.thinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 9, style: .continuous)
+                            .stroke(.white.opacity(0.12), lineWidth: 0.7)
+                    )
+
+                Image(systemName: viewModel.didCreateReminder ? "checkmark.circle.fill" : "calendar")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(viewModel.didCreateReminder ? Color.green : Color.white.opacity(0.84))
+            }
+            .frame(width: 32, height: 32)
 
             TextField(currentExample, text: $viewModel.text)
                 .focused($isTextFieldFocused)
@@ -88,73 +103,77 @@ struct CommandPaletteView: View {
                     }
                 }
                 .textFieldStyle(.plain)
-                .font(.system(size: 18, weight: .regular))
+                .font(.system(size: 19, weight: .regular))
+                .foregroundStyle(.white)
                 .disabled(viewModel.isSubmitting || viewModel.didCreateReminder)
                 .accessibilityIdentifier("quickAddTextField")
+                .frame(height: 34)
 
             if viewModel.isSubmitting {
                 ProgressView()
                     .controlSize(.small)
+                    .frame(width: 34, height: 34)
             } else if !viewModel.didCreateReminder {
-                KeyBadge(text: "↩")
+                Button {
+                    guard canSubmit else { return }
+                    Task {
+                        await viewModel.submit()
+                    }
+                } label: {
+                    Image(systemName: "arrow.turn.down.left")
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 38, height: 34)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(canSubmit ? Color.blue : Color.blue.opacity(0.45))
+                                .shadow(color: Color.blue.opacity(canSubmit ? 0.28 : 0), radius: 8, x: 0, y: 3)
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSubmit)
+                .accessibilityLabel("Create reminder")
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(height: 52)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.white.opacity(0.06))
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(Color.white.opacity(0.04))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(.white.opacity(0.12), lineWidth: 0.8)
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .stroke(.white.opacity(0.13), lineWidth: 0.8)
                 )
         )
     }
 
-    @ViewBuilder
-    private var feedbackRow: some View {
-        if viewModel.didCreateReminder {
-            HStack(spacing: 7) {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.green)
-                Text("Reminder created")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .transition(.opacity)
-        } else if let error = viewModel.error {
-            HStack(spacing: 7) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.red)
-                Text(error)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
-            }
-            .transition(.opacity)
-        }
-    }
-
     private var footer: some View {
-        HStack(spacing: 8) {
-            KeyBadge(text: "⎋")
-            Text("close")
-                .foregroundStyle(.secondary)
+        HStack(spacing: 6) {
+            let detectedDueDate = viewModel.detectedDueDateDescription
 
-            Text("•")
-                .foregroundStyle(.tertiary)
+            FooterPill(icon: "xmark.circle", text: "Close")
 
-            Text("Include a date or time")
-                .foregroundStyle(.secondary)
+            if viewModel.didCreateReminder {
+                FooterPill(icon: "checkmark.circle.fill", text: "Reminder created", tint: .green)
+            } else if let error = viewModel.error {
+                FooterPill(icon: "exclamationmark.triangle.fill", text: error, tint: .red)
+            } else {
+                FooterPill(
+                    icon: detectedDueDate == nil ? "circle" : "circle.fill",
+                    text: detectedDueDate.map { "Detected: \($0)" } ?? "Detected: none",
+                    tint: detectedDueDate == nil ? .secondary : .green
+                )
+            }
 
-            Spacer()
+            FooterPill(icon: "calendar", text: "Add date/time")
 
-            KeyBadge(text: "⌘")
-            KeyBadge(text: "/")
+            Spacer(minLength: 6)
+
+            FooterPill(text: "⌘", trailingText: "Return")
+            FooterPill(text: "esc")
         }
+        .frame(height: 24)
         .font(.system(size: 11, weight: .medium))
     }
 
@@ -169,20 +188,38 @@ struct CommandPaletteView: View {
     }
 }
 
-struct KeyBadge: View {
+struct FooterPill: View {
+    var icon: String?
     let text: String
+    var trailingText: String?
+    var tint: Color = .secondary
 
     var body: some View {
-        Text(text)
-            .font(.system(size: 10, weight: .semibold))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(.thinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(.white.opacity(0.14), lineWidth: 0.7)
-            )
+        HStack(spacing: 8) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: icon == "circle.fill" ? 6 : 10, weight: .semibold))
+                    .foregroundStyle(tint)
+            }
+
+            Text(text)
+                .lineLimit(1)
+                .foregroundStyle(.white.opacity(0.76))
+
+            if let trailingText {
+                Text(trailingText)
+                    .foregroundStyle(.white.opacity(0.58))
+            }
+        }
+        .font(.system(size: 11, weight: .medium))
+        .padding(.horizontal, 8)
+        .frame(height: 24)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(.white.opacity(0.12), lineWidth: 0.7)
+        )
     }
 }
 

--- a/Palette/CommandPaletteView.swift
+++ b/Palette/CommandPaletteView.swift
@@ -30,6 +30,7 @@ struct CommandPaletteView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             inputRow
+            upcomingRemindersView
             footer
         }
         .padding(.horizontal, 14)
@@ -50,6 +51,7 @@ struct CommandPaletteView: View {
         )
         .background(KeyEventHandling(onEscape: onDismiss))
         .preferredColorScheme(.dark)
+        .animation(.easeOut(duration: 0.16), value: viewModel.upcomingRemindersState)
         .onAppear {
             focusTextField()
         }
@@ -88,18 +90,21 @@ struct CommandPaletteView: View {
                             .stroke(.white.opacity(0.12), lineWidth: 0.7)
                     )
 
-                Image(systemName: viewModel.didCreateReminder ? "checkmark.circle.fill" : "calendar")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(viewModel.didCreateReminder ? Color.green : Color.white.opacity(0.84))
+                if viewModel.didCreateReminder {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.green)
+                } else {
+                    ColorfulCalendarIcon()
+                }
             }
             .frame(width: 32, height: 32)
 
             TextField(currentExample, text: $viewModel.text)
                 .focused($isTextFieldFocused)
                 .onSubmit {
-                    guard canSubmit else { return }
                     Task {
-                        await viewModel.submit()
+                        await viewModel.handleReturn()
                     }
                 }
                 .textFieldStyle(.plain)
@@ -148,6 +153,83 @@ struct CommandPaletteView: View {
         )
     }
 
+    @ViewBuilder
+    private var upcomingRemindersView: some View {
+        switch viewModel.upcomingRemindersState {
+        case .hidden:
+            EmptyView()
+        case .loading:
+            upcomingStateRow(icon: "clock", text: "Loading reminders")
+                .transition(upcomingTransition)
+        case .empty:
+            upcomingStateRow(icon: "checkmark.circle", text: "No upcoming reminders")
+                .transition(upcomingTransition)
+        case .permissionDenied:
+            upcomingStateRow(icon: "lock.fill", text: "Reminders access denied", tint: .orange)
+                .transition(upcomingTransition)
+        case .failed(let message):
+            upcomingStateRow(icon: "exclamationmark.triangle.fill", text: message, tint: .red)
+                .transition(upcomingTransition)
+        case .loaded(let reminders):
+            VStack(spacing: 0) {
+                ForEach(Array(reminders.enumerated()), id: \.element.id) { index, reminder in
+                    UpcomingReminderRow(reminder: reminder)
+
+                    if index < reminders.count - 1 {
+                        Divider()
+                            .overlay(Color.white.opacity(0.08))
+                            .padding(.leading, 38)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                    .fill(Color.white.opacity(0.035))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 13, style: .continuous)
+                            .stroke(.white.opacity(0.11), lineWidth: 0.8)
+                    )
+            )
+            .transition(upcomingTransition)
+        }
+    }
+
+    private var upcomingTransition: AnyTransition {
+        .opacity.combined(with: .move(edge: .top))
+    }
+
+    private func upcomingStateRow(icon: String, text: String, tint: Color = .secondary) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 20)
+
+            Text(text)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white.opacity(0.72))
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+
+            if viewModel.upcomingRemindersState == .loading {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 42)
+        .background(
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(Color.white.opacity(0.035))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                        .stroke(.white.opacity(0.11), lineWidth: 0.8)
+                )
+        )
+    }
+
     private var footer: some View {
         HStack(spacing: 6) {
             let detectedDueDate = viewModel.detectedDueDateDescription
@@ -188,6 +270,61 @@ struct CommandPaletteView: View {
     }
 }
 
+private struct UpcomingReminderRow: View {
+    let reminder: UpcomingReminder
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(Color.blue.opacity(0.18))
+
+                Image(systemName: "bell.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.blue.opacity(0.88))
+            }
+            .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(reminder.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .lineLimit(1)
+
+                Text(formattedDueDate(reminder.dueDate))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.56))
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 44)
+        .contentShape(Rectangle())
+    }
+
+    private func formattedDueDate(_ date: Date) -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.timeStyle = .short
+
+        let calendar = Calendar.current
+        let time = timeFormatter.string(from: date)
+
+        if calendar.isDateInToday(date) {
+            return "Today at \(time)"
+        }
+
+        if calendar.isDateInTomorrow(date) {
+            return "Tomorrow at \(time)"
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.setLocalizedDateFormatFromTemplate("EEE, MMM d")
+        return "\(dateFormatter.string(from: date)) at \(time)"
+    }
+}
+
 struct FooterPill: View {
     var icon: String?
     let text: String
@@ -220,6 +357,61 @@ struct FooterPill: View {
             RoundedRectangle(cornerRadius: 7, style: .continuous)
                 .stroke(.white.opacity(0.12), lineWidth: 0.7)
         )
+    }
+}
+
+struct ColorfulCalendarIcon: View {
+    var body: some View {
+        ZStack(alignment: .top) {
+            RoundedRectangle(cornerRadius: 3.2, style: .continuous)
+                .fill(Color.white.opacity(0.9))
+
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(Color.blue)
+                    .frame(height: 5)
+                Spacer(minLength: 0)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 3.2, style: .continuous))
+
+            VStack(spacing: 2) {
+                Spacer()
+                    .frame(height: 7)
+
+                HStack(spacing: 2) {
+                    ForEach(0..<3, id: \.self) { _ in
+                        dateDot
+                    }
+                }
+
+                HStack(spacing: 2) {
+                    ForEach(0..<3, id: \.self) { _ in
+                        dateDot
+                    }
+                }
+            }
+
+            HStack(spacing: 5) {
+                bindingTab
+                bindingTab
+            }
+            .offset(y: -1)
+        }
+        .frame(width: 16, height: 16)
+        .shadow(color: Color.blue.opacity(0.18), radius: 4, x: 0, y: 1)
+        .accessibilityLabel("Calendar")
+    }
+
+    private var dateDot: some View {
+        RoundedRectangle(cornerRadius: 0.6, style: .continuous)
+            .fill(Color.black.opacity(0.28))
+            .frame(width: 2, height: 2)
+    }
+
+    private var bindingTab: some View {
+        RoundedRectangle(cornerRadius: 0.8, style: .continuous)
+            .fill(Color.white.opacity(0.96))
+            .frame(width: 2, height: 4)
     }
 }
 

--- a/Palette/CommandPaletteWindowController.swift
+++ b/Palette/CommandPaletteWindowController.swift
@@ -2,6 +2,7 @@
 import AppKit
 import SwiftUI
 import QuartzCore
+import Combine
 
 final class KeyablePanel: NSPanel {
     var onCancel: (() -> Void)?
@@ -28,14 +29,19 @@ final class CommandPaletteWindowController: NSWindowController {
     private var hostingView: NSHostingView<CommandPaletteView>!
     private var isAnimatingHide = false
     private var observers: [NSObjectProtocol] = []
+    private var cancellables: Set<AnyCancellable> = []
 
-    private let paletteSize = NSSize(width: 520, height: 110)
+    private static let paletteWidth: CGFloat = 520
+    private static let minimumPaletteHeight: CGFloat = 110
+    private static var paletteSize: NSSize {
+        NSSize(width: paletteWidth, height: minimumPaletteHeight)
+    }
 
     init(viewModel: PaletteViewModel) {
         self.viewModel = viewModel
 
         let panel = KeyablePanel(
-            contentRect: NSRect(origin: .zero, size: paletteSize),
+            contentRect: NSRect(origin: .zero, size: Self.paletteSize),
             styleMask: [.borderless],
             backing: .buffered,
             defer: false
@@ -63,6 +69,15 @@ final class CommandPaletteWindowController: NSWindowController {
         self.hostingView.canDrawConcurrently = false
         panel.contentView = self.hostingView
         panel.initialFirstResponder = self.hostingView
+
+        viewModel.$upcomingRemindersState
+            .dropFirst()
+            .sink { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.resizeToFitContent()
+                }
+            }
+            .store(in: &cancellables)
 
         observers = [
             NotificationCenter.default.addObserver(
@@ -108,7 +123,7 @@ final class CommandPaletteWindowController: NSWindowController {
 
         viewModel.reset()
         viewModel.requestFocus()
-        window.setFrame(centeredFrame(for: paletteSize), display: false)
+        window.setFrame(centeredFrame(for: Self.paletteSize), display: false)
 
         let finalFrame = window.frame
         var startFrame = finalFrame
@@ -133,6 +148,7 @@ final class CommandPaletteWindowController: NSWindowController {
                 window.makeFirstResponder(self.hostingView)
                 self.viewModel.requestFocus()
                 NSApp.activate(ignoringOtherApps: true)
+                self.resizeToFitContent(animated: false)
             }
         }
     }
@@ -187,6 +203,30 @@ final class CommandPaletteWindowController: NSWindowController {
         return NSScreen.screens.first { screen in
             NSMouseInRect(mouseLocation, screen.frame, false)
         } ?? NSScreen.main
+    }
+
+    private func resizeToFitContent(animated: Bool = true) {
+        guard let window, window.isVisible else { return }
+
+        hostingView.layoutSubtreeIfNeeded()
+        let fittingHeight = max(Self.minimumPaletteHeight, ceil(hostingView.fittingSize.height))
+        guard abs(window.frame.height - fittingHeight) > 0.5 else { return }
+
+        var targetFrame = window.frame
+        let topY = targetFrame.maxY
+        targetFrame.size = NSSize(width: Self.paletteWidth, height: fittingHeight)
+        targetFrame.origin.y = topY - fittingHeight
+
+        guard animated else {
+            window.setFrame(targetFrame, display: true)
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.14
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            window.animator().setFrame(targetFrame, display: true)
+        }
     }
 }
 #endif

--- a/Palette/CommandPaletteWindowController.swift
+++ b/Palette/CommandPaletteWindowController.swift
@@ -54,7 +54,7 @@ final class CommandPaletteWindowController: NSWindowController {
         panel.backgroundColor = .clear
         panel.titleVisibility = .hidden
         panel.acceptsMouseMovedEvents = true
-        panel.hasShadow = true
+        panel.hasShadow = false
 
         super.init(window: panel)
 

--- a/Palette/CommandPaletteWindowController.swift
+++ b/Palette/CommandPaletteWindowController.swift
@@ -29,7 +29,7 @@ final class CommandPaletteWindowController: NSWindowController {
     private var isAnimatingHide = false
     private var observers: [NSObjectProtocol] = []
 
-    private let paletteSize = NSSize(width: 520, height: 168)
+    private let paletteSize = NSSize(width: 520, height: 110)
 
     init(viewModel: PaletteViewModel) {
         self.viewModel = viewModel
@@ -48,7 +48,7 @@ final class CommandPaletteWindowController: NSWindowController {
         panel.backgroundColor = .clear
         panel.titleVisibility = .hidden
         panel.acceptsMouseMovedEvents = true
-        panel.hasShadow = false
+        panel.hasShadow = true
 
         super.init(window: panel)
 

--- a/Services/EventKitRemindersService.swift
+++ b/Services/EventKitRemindersService.swift
@@ -63,6 +63,46 @@ final class EventKitRemindersService: RemindersAPI, ReminderListProviding, @unch
 #endif
     }
 
+    func upcomingReminders(limit: Int) async throws -> [UpcomingReminder] {
+        guard limit > 0 else { return [] }
+
+        guard try await requestRemindersAccess() else {
+#if canImport(os)
+            os_log("EventKit access denied while loading upcoming reminders", log: .services, type: .error)
+#endif
+            throw EventKitError.accessDenied
+        }
+
+        let predicate = store.predicateForIncompleteReminders(
+            withDueDateStarting: Date(),
+            ending: nil,
+            calendars: nil
+        )
+
+        let reminders = await withCheckedContinuation { continuation in
+            store.fetchReminders(matching: predicate) { reminders in
+                continuation.resume(returning: reminders ?? [])
+            }
+        }
+
+        return reminders
+            .compactMap { reminder -> UpcomingReminder? in
+                guard let dueDateComponents = reminder.dueDateComponents,
+                      let dueDate = Calendar.current.date(from: dueDateComponents) else {
+                    return nil
+                }
+
+                return UpcomingReminder(
+                    id: reminder.calendarItemIdentifier,
+                    title: reminder.title ?? "Untitled reminder",
+                    dueDate: dueDate
+                )
+            }
+            .sorted { $0.dueDate < $1.dueDate }
+            .prefix(limit)
+            .map { $0 }
+    }
+
     private func requestRemindersAccess() async throws -> Bool {
         if #available(macOS 14.0, *) {
             return try await store.requestFullAccessToReminders()

--- a/Services/RemindersAPI.swift
+++ b/Services/RemindersAPI.swift
@@ -5,8 +5,15 @@ struct ReminderList: Identifiable, Equatable, Sendable {
     let title: String
 }
 
+struct UpcomingReminder: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let dueDate: Date
+}
+
 protocol RemindersAPI: Sendable {
     func createReminder(title: String, dueDate: Date?, calendarIdentifier: String?) async throws
+    func upcomingReminders(limit: Int) async throws -> [UpcomingReminder]
 }
 
 protocol ReminderListProviding: Sendable {
@@ -15,9 +22,24 @@ protocol ReminderListProviding: Sendable {
 
 actor MockRemindersAPI: RemindersAPI {
     private var created: [(title: String, dueDate: Date?, calendarIdentifier: String?)] = []
+    private var upcoming: [UpcomingReminder]
+    private var upcomingError: Error?
+
+    init(upcoming: [UpcomingReminder] = [], upcomingError: Error? = nil) {
+        self.upcoming = upcoming
+        self.upcomingError = upcomingError
+    }
 
     func createReminder(title: String, dueDate: Date?, calendarIdentifier: String?) async throws {
         created.append((title: title, dueDate: dueDate, calendarIdentifier: calendarIdentifier))
+    }
+
+    func upcomingReminders(limit: Int) async throws -> [UpcomingReminder] {
+        if let upcomingError {
+            throw upcomingError
+        }
+
+        return Array(upcoming.sorted { $0.dueDate < $1.dueDate }.prefix(max(limit, 0)))
     }
 
     var createdReminders: [(title: String, dueDate: Date?, calendarIdentifier: String?)] {

--- a/SlashRemindTests/PaletteViewModelTests.swift
+++ b/SlashRemindTests/PaletteViewModelTests.swift
@@ -97,6 +97,152 @@ final class PaletteViewModelTests: XCTestCase {
         XCTAssertTrue(scheduled.isEmpty)
     }
 
+    func testEmptyDoubleReturnLoadsUpcomingRemindersSortedByDueDate() async throws {
+        let later = UpcomingReminder(
+            id: "later",
+            title: "Later reminder",
+            dueDate: Date(timeIntervalSinceReferenceDate: 2_000)
+        )
+        let sooner = UpcomingReminder(
+            id: "sooner",
+            title: "Sooner reminder",
+            dueDate: Date(timeIntervalSinceReferenceDate: 1_000)
+        )
+        let mockAPI = MockRemindersAPI(upcoming: [later, sooner])
+        let mockScheduler = MockNotificationScheduler()
+        let settings = SettingsStore(defaults: isolatedDefaults())
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: nil),
+            doubleReturnThreshold: 0.3
+        )
+
+        let firstReturn = Date(timeIntervalSinceReferenceDate: 10_000)
+        await vm.setText("   \n")
+        await vm.handleReturn(now: firstReturn)
+
+        let firstState = await vm.getUpcomingRemindersState()
+        XCTAssertEqual(firstState, .hidden)
+        let firstError = await vm.getError()
+        XCTAssertNil(firstError)
+
+        await vm.handleReturn(now: firstReturn.addingTimeInterval(0.2))
+
+        guard case .loaded(let reminders) = await vm.getUpcomingRemindersState() else {
+            XCTFail("Expected loaded upcoming reminders")
+            return
+        }
+
+        XCTAssertEqual(reminders.map(\.id), ["sooner", "later"])
+
+        let created = await mockAPI.createdReminders
+        XCTAssertTrue(created.isEmpty)
+    }
+
+    func testEmptyReturnOutsideDoublePressThresholdDoesNotRevealOrError() async throws {
+        let mockAPI = MockRemindersAPI(upcoming: [
+            UpcomingReminder(id: "upcoming", title: "Upcoming", dueDate: Date(timeIntervalSinceReferenceDate: 1_000))
+        ])
+        let mockScheduler = MockNotificationScheduler()
+        let settings = SettingsStore(defaults: isolatedDefaults())
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: nil),
+            doubleReturnThreshold: 0.3
+        )
+
+        let firstReturn = Date(timeIntervalSinceReferenceDate: 10_000)
+        await vm.handleReturn(now: firstReturn)
+        await vm.handleReturn(now: firstReturn.addingTimeInterval(0.5))
+
+        let state = await vm.getUpcomingRemindersState()
+        let error = await vm.getError()
+        XCTAssertEqual(state, .hidden)
+        XCTAssertNil(error)
+    }
+
+    func testEmptyDoubleReturnHandlesPermissionDenied() async throws {
+        let mockAPI = MockRemindersAPI(upcomingError: EventKitError.accessDenied)
+        let mockScheduler = MockNotificationScheduler()
+        let settings = SettingsStore(defaults: isolatedDefaults())
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: nil),
+            doubleReturnThreshold: 0.3
+        )
+
+        let firstReturn = Date(timeIntervalSinceReferenceDate: 10_000)
+        await vm.handleReturn(now: firstReturn)
+        await vm.handleReturn(now: firstReturn.addingTimeInterval(0.2))
+
+        let state = await vm.getUpcomingRemindersState()
+        let error = await vm.getError()
+        XCTAssertEqual(state, .permissionDenied)
+        XCTAssertNil(error)
+    }
+
+    func testEmptyReturnClosesVisibleUpcomingReminders() async throws {
+        let mockAPI = MockRemindersAPI(upcoming: [
+            UpcomingReminder(id: "upcoming", title: "Upcoming", dueDate: Date(timeIntervalSinceReferenceDate: 1_000))
+        ])
+        let mockScheduler = MockNotificationScheduler()
+        let settings = SettingsStore(defaults: isolatedDefaults())
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: nil),
+            doubleReturnThreshold: 0.3
+        )
+
+        let firstReturn = Date(timeIntervalSinceReferenceDate: 10_000)
+        await vm.handleReturn(now: firstReturn)
+        await vm.handleReturn(now: firstReturn.addingTimeInterval(0.2))
+
+        guard case .loaded = await vm.getUpcomingRemindersState() else {
+            XCTFail("Expected loaded upcoming reminders")
+            return
+        }
+
+        await vm.handleReturn(now: firstReturn.addingTimeInterval(0.4))
+
+        let state = await vm.getUpcomingRemindersState()
+        XCTAssertEqual(state, .hidden)
+    }
+
+    func testHandleReturnWithTextStillCreatesReminder() async throws {
+        let mockAPI = MockRemindersAPI()
+        let mockScheduler = MockNotificationScheduler()
+        let fixedDate = Date(timeIntervalSince1970: 1704110400)
+        let settings = SettingsStore(defaults: isolatedDefaults())
+
+        let vm = await PaletteViewModel(
+            api: mockAPI,
+            settings: settings,
+            scheduler: mockScheduler,
+            inputParser: MockInputParser(parsed: ParsedReminderInput(title: "Call Sam", dueDate: fixedDate))
+        )
+
+        await vm.setText("Call Sam tomorrow")
+        await vm.handleReturn()
+
+        let reminders = await mockAPI.createdReminders
+        let state = await vm.getUpcomingRemindersState()
+        XCTAssertEqual(reminders.count, 1)
+        XCTAssertEqual(reminders.first?.title, "Call Sam")
+        XCTAssertEqual(state, .hidden)
+    }
+
     private func isolatedDefaults() -> UserDefaults {
         let suiteName = "PaletteViewModelTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -113,6 +259,10 @@ extension PaletteViewModel {
 
     func getError() -> String? {
         return self.error
+    }
+
+    func getUpcomingRemindersState() -> UpcomingRemindersState {
+        return self.upcomingRemindersState
     }
 }
 

--- a/ViewModels/PaletteViewModel.swift
+++ b/ViewModels/PaletteViewModel.swift
@@ -13,6 +13,16 @@ final class PaletteViewModel: ObservableObject {
     private let scheduler: NotificationScheduling
     private let inputParser: ReminderInputParsing
 
+    var detectedDueDateDescription: String? {
+        let message = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty,
+              let parsed = inputParser.parse(message, defaultTime: settings.defaultTimeComponents) else {
+            return nil
+        }
+
+        return formattedDueDate(parsed.dueDate)
+    }
+
     init(api: RemindersAPI, settings: SettingsStore, scheduler: NotificationScheduling, inputParser: ReminderInputParsing) {
         self.api = api
         self.settings = settings
@@ -65,5 +75,25 @@ final class PaletteViewModel: ObservableObject {
         error = nil
         isSubmitting = false
         didCreateReminder = false
+    }
+
+    private func formattedDueDate(_ date: Date) -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.timeStyle = .short
+
+        let calendar = Calendar.current
+        let time = timeFormatter.string(from: date)
+
+        if calendar.isDateInToday(date) {
+            return "Today at \(time)"
+        }
+
+        if calendar.isDateInTomorrow(date) {
+            return "Tomorrow at \(time)"
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return "\(dateFormatter.string(from: date)) at \(time)"
     }
 }

--- a/ViewModels/PaletteViewModel.swift
+++ b/ViewModels/PaletteViewModel.swift
@@ -1,17 +1,37 @@
 import Foundation
 
+enum UpcomingRemindersState: Equatable {
+    case hidden
+    case loading
+    case loaded([UpcomingReminder])
+    case empty
+    case permissionDenied
+    case failed(String)
+}
+
 @MainActor
 final class PaletteViewModel: ObservableObject {
-    @Published var text: String = ""
+    @Published var text: String = "" {
+        didSet {
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                upcomingRemindersState = .hidden
+                lastEmptyReturnDate = nil
+            }
+        }
+    }
     @Published var isSubmitting = false
     @Published var error: String?
     @Published var didCreateReminder = false
     @Published var focusRequestID = 0
+    @Published var upcomingRemindersState: UpcomingRemindersState = .hidden
 
     private let api: RemindersAPI
     private let settings: SettingsStore
     private let scheduler: NotificationScheduling
     private let inputParser: ReminderInputParsing
+    private let doubleReturnThreshold: TimeInterval
+    private var lastEmptyReturnDate: Date?
+    private let upcomingReminderLimit = 5
 
     var detectedDueDateDescription: String? {
         let message = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -23,11 +43,49 @@ final class PaletteViewModel: ObservableObject {
         return formattedDueDate(parsed.dueDate)
     }
 
-    init(api: RemindersAPI, settings: SettingsStore, scheduler: NotificationScheduling, inputParser: ReminderInputParsing) {
+    init(
+        api: RemindersAPI,
+        settings: SettingsStore,
+        scheduler: NotificationScheduling,
+        inputParser: ReminderInputParsing,
+        doubleReturnThreshold: TimeInterval = 0.32
+    ) {
         self.api = api
         self.settings = settings
         self.scheduler = scheduler
         self.inputParser = inputParser
+        self.doubleReturnThreshold = doubleReturnThreshold
+    }
+
+    func handleReturn(now: Date = Date()) async {
+        let message = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard message.isEmpty else {
+            lastEmptyReturnDate = nil
+            guard !isSubmitting, !didCreateReminder else { return }
+            await submit()
+            return
+        }
+
+        guard !isSubmitting else { return }
+
+        error = nil
+        didCreateReminder = false
+
+        if upcomingRemindersState != .hidden {
+            upcomingRemindersState = .hidden
+            lastEmptyReturnDate = nil
+            requestFocus()
+            return
+        }
+
+        if let lastEmptyReturnDate,
+           now.timeIntervalSince(lastEmptyReturnDate) <= doubleReturnThreshold {
+            self.lastEmptyReturnDate = nil
+            await revealUpcomingReminders()
+            return
+        }
+
+        lastEmptyReturnDate = now
     }
 
     func submit() async {
@@ -66,6 +124,25 @@ final class PaletteViewModel: ObservableObject {
         }
     }
 
+    func revealUpcomingReminders() async {
+        upcomingRemindersState = .loading
+        error = nil
+
+        do {
+            let reminders = try await api.upcomingReminders(limit: upcomingReminderLimit)
+                .sorted { $0.dueDate < $1.dueDate }
+
+            upcomingRemindersState = reminders.isEmpty ? .empty : .loaded(reminders)
+            requestFocus()
+        } catch EventKitError.accessDenied {
+            upcomingRemindersState = .permissionDenied
+            requestFocus()
+        } catch {
+            upcomingRemindersState = .failed("Couldn’t load reminders")
+            requestFocus()
+        }
+    }
+
     func requestFocus() {
         focusRequestID += 1
     }
@@ -75,6 +152,8 @@ final class PaletteViewModel: ObservableObject {
         error = nil
         isSubmitting = false
         didCreateReminder = false
+        upcomingRemindersState = .hidden
+        lastEmptyReturnDate = nil
     }
 
     private func formattedDueDate(_ date: Date) -> String {


### PR DESCRIPTION
 Implemented the upcoming reminders reveal.

  Changed:

  - Services/RemindersAPI.swift: added UpcomingReminder and upcomingReminders(limit:).
  - Services/EventKitRemindersService.swift: fetches incomplete reminders due from now onward, sorted ascending, without logging reminder contents.
  - ViewModels/PaletteViewModel.swift: added quick double-Return handling, loading/empty/permission/error states, and preserved normal submit behavior for non-empty text.
  - Palette/CommandPaletteView.swift: added the compact animated reminders reveal with native dark styling and state rows.
  - Palette/CommandPaletteWindowController.swift: added dynamic panel resizing so the palette expands only as needed.
  - SlashRemindTests/PaletteViewModelTests.swift: added coverage for double Return, sorting, threshold behavior, permission denied, and normal creation via Return.

 When the upcoming reminders view is visible and the input is empty, pressing Return now hides the list and keeps focus in the palette.

Added a unit test for that toggle behavior in SlashRemindTests/PaletteViewModelTests.swift